### PR TITLE
Refactor tractor

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <script src="https://code.jquery.com/jquery-2.2.0.min.js"></script>
 
   <div class="container">
+    <div style="display: none" id="orientation_button">Vertical</div>
     <h2 class="info">Level: <span id="game_level">1</span></h2>
     <h2 class="info">High Score: <span id="high_score">1</span> </h2>
   </div>

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,6 +62,19 @@ zeus.canvas.addEventListener('click', function(event) {
   }
 });
 
+$( "#orientation_button" ).click(function() {
+  var current = tracker.orientation;
+  var direction = document.getElementById('direction');
+  var gameBoard = document.getElementById('game');
+  if (current === 0){ tracker.orientation = 1; direction.innerHTML = "vertical",
+  gameBoard.setAttribute('class', 'up_down'),
+  this.innerHTML = "Horizontal"};
+  if (current === 1){ tracker.orientation = 0; direction.innerHTML = "horizontal",
+  gameBoard.setAttribute('class', 'left_right'),
+  this.innerHTML = "Vertical"};
+  $(this).fadeTo('fast', 0.6).fadeTo('fast', 1);
+});
+
 function getCursorPosition(canvas, event) {
     var rect = canvas.getBoundingClientRect();
     var x = event.clientX - rect.left;

--- a/lib/zeus.js
+++ b/lib/zeus.js
@@ -29,11 +29,9 @@ Zeus.prototype.initializeBall = function() {
 };
 
 Zeus.prototype.initializeWall = function() {
-  // var lastKeyPress = tracker.orientation
-  var that = this;
   this.walls.forEach(function(wall) {
-    wall.draw(wall.context).move(that.canvasWidth, that.canvasHeight, that.walls);
-  });
+    wall.draw(wall.context).move(this.canvasWidth, this.canvasHeight, this.walls);
+  }.bind());
 };
 
 Zeus.prototype.existingCanvas = function(){

--- a/main.css
+++ b/main.css
@@ -51,6 +51,16 @@ h1{
  #game_start{
    padding-top: 50px;
  }
+ #orientation_button{
+   border: 1px solid #fff;
+   padding: 20px;
+   width: 100px;
+   margin: auto;
+   margin-top: 10px;
+   border-radius: 5px;
+   background-color: rgba(255,255,255,0.3);
+   cursor: pointer;
+ }
 #game_start_button, #play_again_button, #next_level_button {
   border: 1px solid #fff;
   padding: 20px;
@@ -79,3 +89,9 @@ background-color: rgba(255,255,255,0.7);
   margin-right: 15px;
   color: white;
 }
+
+@media only screen and (max-device-width: 600px) {
+		#orientation_button {
+			display: block;
+		}
+	}


### PR DESCRIPTION
@rrgayhart, I added the button for use on mobile, and more recently refactored an instance of that=this to use bind to pass the context of this. 

**What does this PR do?**  
It removes an instance of writing  

```
that = this
```

and instead uses bind to pass the context of 'this' down to a function that animates the walls in the game. It also adds a button to change the wall orientation on mobile.  

*_Where should the review start? *_ 
In the zeus.js file

**How should this manually be tested?**
Clone the repo, then run npm install and npm start to start the server. Open a window in the browser and try to draw a wall in the game. If the wall draws, it ain't broken. Click the 'vertical' button and draw a wall. If the wall draws, it ain't broken. 

**Background context**
I've been procrastinating on implementing JavaScript binds instead of my favorite little trick of setting that equal to this, and passing that along like a hot potato. I actually tried this first on IdeaBox, but couldn't get it to work in that context, so I decided to find a more simple example here in the GameTime project. Bind is now used to pass down the context of the zeus object, which holds the canvas dimensions information.   

*_What gif best describes this PR or how it makes you feel?  *_
![gif](http://i.giphy.com/3o7WTCBePyp2GCamIM.gif)
